### PR TITLE
fix: validate all action inputs

### DIFF
--- a/scripts/build-json.sh
+++ b/scripts/build-json.sh
@@ -17,6 +17,11 @@ set -euo pipefail
 : "${LB_OUTPUT_PATH:?must be set}"
 : "${LB_TMPDIR:?must be set}"
 
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_stats_range "$LB_STATS_RANGE"
+validate_output_path "$LB_OUTPUT_PATH"
+
 # ---------------------------------------------------------------------------
 # Ensure parent directory of output path exists
 # ---------------------------------------------------------------------------

--- a/scripts/fetch-listens.sh
+++ b/scripts/fetch-listens.sh
@@ -19,6 +19,11 @@ API_BASE="https://api.listenbrainz.org/1/user"
 : "${LB_RECENT_COUNT:?must be set}"
 : "${LB_TMPDIR:?must be set}"
 
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_username "$LB_USERNAME"
+validate_positive_integer "recent_count" "$LB_RECENT_COUNT"
+
 # ---------------------------------------------------------------------------
 # 1. Create temp directory if it doesn't exist
 # ---------------------------------------------------------------------------
@@ -74,6 +79,7 @@ if [ "$COUNT_STATUS" -eq 200 ]; then
   echo "Total listen count: ${TOTAL}"
 else
   echo "Warning: Could not fetch listen count (HTTP ${COUNT_STATUS}), skipping" >&2
+  echo "null" > "$LB_TMPDIR/listen-count.json"
 fi
 
 rm -f "$LB_TMPDIR/count-response.tmp"

--- a/scripts/fetch-stats.sh
+++ b/scripts/fetch-stats.sh
@@ -21,6 +21,12 @@ API_BASE="https://api.listenbrainz.org/1/stats/user"
 : "${LB_TOP_COUNT:?must be set}"
 : "${LB_TMPDIR:?must be set}"
 
+# shellcheck source=validate-inputs.sh
+source "$(dirname "$0")/validate-inputs.sh"
+validate_username "$LB_USERNAME"
+validate_stats_range "$LB_STATS_RANGE"
+validate_positive_integer "top_count" "$LB_TOP_COUNT"
+
 # ---------------------------------------------------------------------------
 # Create temp directory if it doesn't exist
 # ---------------------------------------------------------------------------

--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# validate-inputs.sh
+# Shared input validation for all scripts.
+# Source this file, then call the needed validators.
+
+validate_username() {
+  if [[ ! "$1" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "Error: Invalid username format. Must be alphanumeric, hyphens, or underscores." >&2
+    exit 1
+  fi
+}
+
+validate_positive_integer() {
+  local name="$1" value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: ${name} must be a positive integer, got '${value}'" >&2
+    exit 1
+  fi
+}
+
+validate_stats_range() {
+  case "$1" in
+    this_week|this_month|this_year|week|month|quarter|half_yearly|all_time) ;;
+    *) echo "Error: Invalid stats_range '${1}'. Must be one of: this_week, this_month, this_year, week, month, quarter, half_yearly, all_time" >&2; exit 1 ;;
+  esac
+}
+
+validate_output_path() {
+  local resolved
+  # realpath -m works on GNU/Linux (GitHub Actions runners) but not macOS.
+  # Fall back to python3 or plain realpath when -m is unavailable.
+  if resolved="$(realpath -m "$1" 2>/dev/null)"; then
+    :
+  elif resolved="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null)"; then
+    :
+  else
+    resolved="$(cd "$(dirname "$1")" 2>/dev/null && pwd)/$(basename "$1")"
+  fi
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    if [[ "$resolved" != "${GITHUB_WORKSPACE}"/* ]]; then
+      echo "Error: output_path must be within the workspace (${GITHUB_WORKSPACE}), got '${resolved}'" >&2
+      exit 1
+    fi
+  fi
+}


### PR DESCRIPTION
## Summary
- Add shared `validate-inputs.sh` with validators for username, numeric inputs, stats_range, and output_path
- Wire validation into all three scripts
- output_path checked against `$GITHUB_WORKSPACE` to prevent path traversal
- listen-count.json always written (null on failure) for cleaner downstream handling

## Test plan
- [x] Valid inputs succeed
- [x] Invalid username rejected (e.g. `../admin`)
- [x] Invalid count rejected (e.g. `5&foo=bar`)
- [x] Invalid stats_range rejected
- [x] Path traversal rejected when GITHUB_WORKSPACE is set
- [x] End-to-end local test passes

Closes #1, closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added systematic input validation across scripts to ensure parameters are correctly formatted and within expected ranges before processing.

* **Bug Fixes**
  * Improved error handling for API requests to provide consistent output format when responses fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->