### PR TITLE
fix: error handling and CI hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,13 @@ name: Test Action
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run action
         uses: ./

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       env:
         LB_USERNAME: ${{ inputs.username }}
         LB_RECENT_COUNT: ${{ inputs.recent_count }}
-        LB_TMPDIR: ${{ runner.temp }}/listenbrainz
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
 
     - name: Fetch stats
       shell: bash
@@ -43,7 +43,7 @@ runs:
         LB_USERNAME: ${{ inputs.username }}
         LB_STATS_RANGE: ${{ inputs.stats_range }}
         LB_TOP_COUNT: ${{ inputs.top_count }}
-        LB_TMPDIR: ${{ runner.temp }}/listenbrainz
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
 
     - name: Build JSON
       shell: bash
@@ -52,4 +52,11 @@ runs:
         LB_USERNAME: ${{ inputs.username }}
         LB_STATS_RANGE: ${{ inputs.stats_range }}
         LB_OUTPUT_PATH: ${{ inputs.output_path }}
-        LB_TMPDIR: ${{ runner.temp }}/listenbrainz
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf "$LB_TMPDIR"
+      env:
+        LB_TMPDIR: ${{ runner.temp }}/listenbrainz-${{ github.run_id }}

--- a/scripts/fetch-stats.sh
+++ b/scripts/fetch-stats.sh
@@ -55,17 +55,24 @@ fetch_stat() {
   echo "Fetching ${output_name} for user: ${LB_USERNAME} (range: ${LB_STATS_RANGE}, count: ${LB_TOP_COUNT})"
 
   local http_status
-  http_status=$(curl -s -w "%{http_code}" -o "$tmp_file" \
+  http_status=$(curl -s -L --max-redirs 3 -w "%{http_code}" -o "$tmp_file" \
     --max-time 30 --connect-timeout 10 \
     "$url") || http_status="000"
 
   if [ "$http_status" -eq 200 ]; then
-    jq "[.payload.${array_key}[] | ${jq_filter}]" "$tmp_file" > "$LB_TMPDIR/${output_name}.json"
-    echo "ok" > "$LB_TMPDIR/${output_name}-status.txt"
-    jq ".payload.${total_key}" "$tmp_file" > "$LB_TMPDIR/${output_name}-total.txt"
-    local count
-    count=$(jq length "$LB_TMPDIR/${output_name}.json")
-    echo "Wrote ${count} ${output_name} to ${LB_TMPDIR}/${output_name}.json"
+    if jq empty "$tmp_file" 2>/dev/null && \
+       jq "[.payload.${array_key}[] | ${jq_filter}]" "$tmp_file" > "$LB_TMPDIR/${output_name}.json" 2>/dev/null; then
+      echo "ok" > "$LB_TMPDIR/${output_name}-status.txt"
+      jq ".payload.${total_key}" "$tmp_file" > "$LB_TMPDIR/${output_name}-total.txt" 2>/dev/null || echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+      local count
+      count=$(jq length "$LB_TMPDIR/${output_name}.json")
+      echo "Wrote ${count} ${output_name} to ${LB_TMPDIR}/${output_name}.json"
+    else
+      echo "[]" > "$LB_TMPDIR/${output_name}.json"
+      echo "error" > "$LB_TMPDIR/${output_name}-status.txt"
+      echo "null" > "$LB_TMPDIR/${output_name}-total.txt"
+      echo "Warning: Failed to parse ${output_name} response as expected JSON" >&2
+    fi
   elif [ "$http_status" -eq 204 ]; then
     echo "[]" > "$LB_TMPDIR/${output_name}.json"
     echo "no_data" > "$LB_TMPDIR/${output_name}-status.txt"
@@ -86,14 +93,14 @@ fetch_stat() {
 # ---------------------------------------------------------------------------
 fetch_stat "artists" "artists" \
   '{name: .artist_name, listenCount: .listen_count, artistMbid: (.artist_mbid // null)}' \
-  "artists" "total_artist_count" || true
+  "artists" "total_artist_count"
 
 fetch_stat "recordings" "recordings" \
   '{track: .track_name, artist: .artist_name, listenCount: .listen_count, recordingMbid: (.recording_mbid // null), caaReleaseMbid: (.caa_release_mbid // null), caaId: (.caa_id // null)}' \
-  "recordings" "total_recording_count" || true
+  "recordings" "total_recording_count"
 
 fetch_stat "releases" "releases" \
   '{album: .release_name, artist: .artist_name, listenCount: .listen_count, caaReleaseMbid: (.caa_release_mbid // null), caaId: (.caa_id // null)}' \
-  "releases" "total_release_count" || true
+  "releases" "total_release_count"
 
 echo "fetch-stats.sh completed successfully"


### PR DESCRIPTION
## Summary
- Replace `|| true` with internal jq error handling in fetch-stats.sh
- Add JSON validation before jq processing in fetch-listens.sh
- Truncate error response output to 500 bytes
- Remove pull_request trigger from test workflow (fork safety)
- Pin actions/checkout to SHA
- Use run-id in temp dir path for isolation
- Add cleanup step for intermediate files
- Add curl -L for redirect following
- Add permissions block to README example

## Test plan
- [x] End-to-end test with gvns (no stats) passes
- [x] Stats 204 handled gracefully with no_data status
- [x] Final JSON assembled correctly

Closes #3, closes #4, closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for API requests with automatic redirect support.
  * Added JSON validation to prevent processing invalid responses.
  * Enhanced temporary file cleanup and management.

* **Documentation**
  * Updated workflow examples with explicit permissions configuration.

* **Chores**
  * Workflow configuration updates for consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->