### PR TITLE
chore: add FOSS release docs and harden CI permissions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ggfevans]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at admin@gvns.ca. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for your interest in contributing to this project.
+
+## Reporting Bugs
+
+Open a [GitHub issue](https://github.com/ggfevans/listenbrainz-github-action/issues/new) with:
+
+- What you expected to happen
+- What actually happened
+- Your workflow configuration (redact your username if you prefer)
+- Any relevant log output from the action run
+
+## Suggesting Features
+
+Open an issue describing the use case. This action is intentionally minimal -- it fetches data from ListenBrainz and writes JSON. Features that add complexity without broad utility may not be accepted.
+
+## Submitting Pull Requests
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes
+3. Test locally if possible (see below)
+4. Open a PR against `main` with a clear description of what changed and why
+
+Keep PRs focused on a single change. If you're fixing a bug and also want to refactor something, open separate PRs.
+
+## Development Setup
+
+The action is pure bash. You need:
+
+- **bash** (4.0+)
+- **curl**
+- **jq**
+
+There is no build step, no package manager, and no runtime dependencies beyond these.
+
+### Running Locally
+
+You can test the scripts directly by setting the required environment variables:
+
+```bash
+export LB_USERNAME="your-listenbrainz-username"
+export LB_RECENT_COUNT="5"
+export LB_STATS_RANGE="this_month"
+export LB_TOP_COUNT="5"
+export LB_TMPDIR="$(mktemp -d)"
+export LB_OUTPUT_PATH="./test-output/music.json"
+
+bash scripts/fetch-listens.sh
+bash scripts/fetch-stats.sh
+bash scripts/build-json.sh
+
+cat "$LB_OUTPUT_PATH" | jq .
+rm -rf "$LB_TMPDIR"
+```
+
+### Code Style
+
+- Use `set -euo pipefail` in all scripts
+- Quote all variable expansions
+- Validate all inputs before use
+- Send error/warning messages to stderr
+- Keep scripts focused -- no unnecessary dependencies
+
+## Security Issues
+
+Do not open public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for reporting instructions.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| v1.x    | Yes       |
+
+Only the latest release is actively supported with security fixes.
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Instead, please report them through GitHub's private security advisory feature:
+
+1. Go to the [Security Advisories page](https://github.com/ggfevans/listenbrainz-github-action/security/advisories)
+2. Click **"New draft security advisory"**
+3. Fill in the details of the vulnerability
+
+You should receive an initial response within 72 hours. If the vulnerability is confirmed, a fix will be developed privately and released as a patch before the advisory is made public.
+
+## Scope
+
+This action runs as a composite GitHub Action using bash scripts. It makes read-only HTTP requests to the public ListenBrainz API and writes a JSON file to the caller's repository.
+
+Security-relevant areas include:
+
+- **Input validation** -- all action inputs are validated before use
+- **Path traversal** -- the output path is checked against `GITHUB_WORKSPACE`
+- **Command injection** -- inputs are restricted to safe character sets
+- **Temporary file handling** -- temp files are scoped per run and cleaned up
+
+## Out of Scope
+
+- Vulnerabilities in the ListenBrainz API itself (report those to [MetaBrainz](https://metabrainz.org))
+- Vulnerabilities in GitHub Actions runner infrastructure
+- Issues requiring the caller to have already misconfigured their workflow permissions


### PR DESCRIPTION
## Summary
- Add **SECURITY.md** — vulnerability reporting via GitHub Security Advisories, scope definition
- Add **CONTRIBUTING.md** — bug reports, PR process, local dev setup, code style guidelines
- Add **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 (enforcement: admin@gvns.ca)
- Add **.github/FUNDING.yml** — GitHub Sponsors for ggfevans
- Add `permissions: { contents: read }` to test workflow for least-privilege CI

## Test plan
- [ ] Verify SECURITY.md advisory link resolves correctly
- [ ] Verify GitHub Sponsors button appears on repo page
- [ ] Confirm test workflow still passes with new permissions block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct document establishing community guidelines and enforcement policies
  * Added contributing guidelines with development setup instructions and submission process
  * Added security policy documentation outlining vulnerability reporting procedures
  * Added GitHub funding manifest configuration

* **Chores**
  * Updated workflow permissions configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->